### PR TITLE
Fix text contrast failures across app

### DIFF
--- a/antipratik-ui/CLAUDE.md
+++ b/antipratik-ui/CLAUDE.md
@@ -139,9 +139,15 @@ These tokens were added or modified during implementation (not in the original d
 | `--nav-height-default` | `48px` | Alias for clarity in FilterBar CSS |
 | `--z-navbar` | `100` | Navbar z-index |
 | `--z-filterbar` | `90` | FilterBar z-index — must sit below navbar |
-| `--color-text-muted-dark` | `#607D96` | **Changed from `#3A5068`** — original was too dark against `#0A0E14` player background |
+| `--color-text-muted-dark` | `#7A9AB4` | **Changed from `#3A5068` → `#607D96` → `#7A9AB4`** — previous values failed contrast on dark bg; affects navbar links, hero text, section meta |
+| `--color-text-subtle-dark` | `#4A6A84` | **Changed from `#2E3748`** — was identical to `--color-border-dark`, near-invisible; affects ExternalLinksBlock labels and arrows |
+| `--link-domain-color-dark` | `#4A6A84` | **Changed from `#2E3748`** — domain text in ExternalLinksBlock (dark mode) was unreadable |
+| `--nl-legal-color` | `#607D96` | **Changed from `#1E2535`** — legal text on `#0A0E14` newsletter bg was near-zero contrast |
+| `--color-text-subtle-light` | `#7A7268` | **Changed from `#C8C0B4`** — was too close to parchment bg, near-invisible |
+| `--link-domain-color-light` | `#8A8070` | **Changed from `#C8C0B4`** — domain text in ExternalLinksBlock (light mode) was unreadable |
+| `--color-text-muted-light` | `#4A5860` | **Changed from `#7A8890`** — navbar links and section meta on parchment bg were below WCAG AA |
 
-The `--color-text-muted-dark` change is global and affects every component using it.
+These contrast fixes are global — every component using these tokens benefits automatically.
 
 ---
 
@@ -293,3 +299,4 @@ ThemeProvider
 13. **Call setState on a different component inside a state updater function** — use a separate `useEffect` to trigger cross-component state changes.
 14. **Link essays to `/post/${slug}`** — correct path is `/${slug}`. Next.js catch-all handles it.
 15. **Use `--accent-*` colors on UI chrome elements** — accent tokens are for content only.
+16. **Set text color tokens below minimum contrast** — all text tokens must achieve ≥ 4.5:1 (WCAG AA normal text) or ≥ 3:1 (large/bold text) against their expected background. "Subtle" is for de-emphasis, not invisibility. Verify contrast before changing any `--color-text-*`, `--link-*-color`, or `--nl-*-color` token.

--- a/antipratik-ui/src/styles/tokens.css
+++ b/antipratik-ui/src/styles/tokens.css
@@ -127,8 +127,8 @@
 --color-text-primary-dark:           #EEF2F0;  /* snow — headings, primary text */
 --color-text-sub-dark:               #C8D8E8;  /* sub-headings */
 --color-text-body-dark:              #8BACC4;  /* long-form body copy */
---color-text-muted-dark:             #607D96;  /* album names, meta, dates */
---color-text-subtle-dark:            #2E3748;  /* barely visible — meta, hints */
+--color-text-muted-dark:             #7A9AB4;  /* album names, meta, dates */
+--color-text-subtle-dark:            #4A6A84;  /* subtle — meta, hints */
 
 /* ═══════════════════════════════════════════════
    LIGHT MODE SURFACES — Parchment
@@ -141,8 +141,8 @@
 /* Light mode text */
 --color-text-primary-light:          #0F1118;
 --color-text-body-light:             #2A3A4A;  /* slightly blue-grey — not pure black */
---color-text-muted-light:            #7A8890;
---color-text-subtle-light:           #C8C0B4;
+--color-text-muted-light:            #4A5860;
+--color-text-subtle-light:           #7A7268;
 
 /* Mountain landscape */
 --color-night-sky:                   #2A4A66;
@@ -386,7 +386,7 @@
 --nl-btn-bg-hover:                   #ffffff;
 --nl-btn-bg-active:                  #D8D2C4;
 --nl-btn-color:                      #0F1118;
---nl-legal-color:                    #1E2535;
+--nl-legal-color:                    #607D96;
 --nl-legal-size:                     11px;
 --nl-error-color:                    #E03E35;
 --nl-success-icon-color:             #5E9E6A;
@@ -423,8 +423,8 @@
 --link-desc-color-dark:              #3A5068;
 --link-desc-color-light:             #A0A090;
 --link-domain-size:                  10px;
---link-domain-color-dark:            #2E3748;
---link-domain-color-light:           #C8C0B4;
+--link-domain-color-dark:            #4A6A84;
+--link-domain-color-light:           #8A8070;
 --link-accent-music:                 #E03E35;
 --link-accent-writing:               #4A7FBB;
 --link-accent-video:                 #5E9E6A;


### PR DESCRIPTION
Closes #7

## Summary

- Seven CSS token values were too close to their background colours, producing text that failed or nearly failed WCAG AA contrast
- All fixes are token-only in `tokens.css` — no component CSS needed to change
- Also updated `CLAUDE.md` to document the changed values and add Rule 16 (minimum contrast standard) to prevent future regressions

## Token changes

| Token | Before | After |
|---|---|---|
| `--color-text-muted-dark` | `#607D96` | `#7A9AB4` |
| `--color-text-muted-light` | `#7A8890` | `#4A5860` |
| `--color-text-subtle-dark` | `#2E3748` | `#4A6A84` |
| `--color-text-subtle-light` | `#C8C0B4` | `#7A7268` |
| `--link-domain-color-dark` | `#2E3748` | `#4A6A84` |
| `--link-domain-color-light` | `#C8C0B4` | `#8A8070` |
| `--nl-legal-color` | `#1E2535` | `#607D96` |

## Test plan

- [ ] Navbar links readable in both dark and light modes
- [ ] Domain text (e.g. "soundcloud.com") visible in both modes on homepage / links page
- [ ] NE arrow on external link rows visible in dark mode at rest
- [ ] "No spam, ever. Unsubscribe any time." readable in the newsletter block
- [ ] Hero eyebrow and description text readable on dark hero background
- [ ] Category labels in ExternalLinksBlock ("MUSIC", "WRITING") readable in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)