### PR TITLE
improve newsletter block background contrast in both themes — closes #8

### DIFF
--- a/antipratik-ui/CLAUDE.md
+++ b/antipratik-ui/CLAUDE.md
@@ -100,7 +100,7 @@ const { slug } = await params;
 All tokens live in `src/styles/tokens.css`. Never import tokens.css anywhere except `src/app/layout.tsx`.
 
 | Prefix | Category |
-|--------|----------|
+|--------|-----------|
 | `--font-serif`, `--font-sans` | Typefaces |
 | `--text-*` | Type scale (display/h1/h2/h3/body/ui/meta/label/micro) |
 | `--lh-*` | Line heights |
@@ -142,7 +142,9 @@ These tokens were added or modified during implementation (not in the original d
 | `--color-text-muted-dark` | `#7A9AB4` | **Changed from `#3A5068` → `#607D96` → `#7A9AB4`** — previous values failed contrast on dark bg; affects navbar links, hero text, section meta |
 | `--color-text-subtle-dark` | `#4A6A84` | **Changed from `#2E3748`** — was identical to `--color-border-dark`, near-invisible; affects ExternalLinksBlock labels and arrows |
 | `--link-domain-color-dark` | `#4A6A84` | **Changed from `#2E3748`** — domain text in ExternalLinksBlock (dark mode) was unreadable |
-| `--nl-legal-color` | `#607D96` | **Changed from `#1E2535`** — legal text on `#0A0E14` newsletter bg was near-zero contrast |
+| `--nl-legal-color` | `#607D96` (root) / `#7A9AB4` (per theme) | **Root changed from `#1E2535`**; then per-theme overrides added in `[data-theme]` blocks — `#607D96` fails WCAG AA on elevated newsletter bg (#8); both themes now use `var(--color-text-muted-dark)` = `#7A9AB4` |
+| `--nl-bg` | `#0A0E14` (root fallback) / `#181D28` dark / `#1C2B3A` light | **Per-theme overrides added** — `#0A0E14` was indistinguishable from dark page bg and jarring in light mode; dark now uses `--color-surface-dark`, light uses `--color-stone` (#8) |
+| `--nl-input-bg` | `#181D28` (root) / `#0F1118` dark | **Dark mode override added** — input bg must be darker than new block bg `#181D28` to remain visible; overridden to `--color-bg-dark` in dark mode (#8) |
 | `--color-text-subtle-light` | `#7A7268` | **Changed from `#C8C0B4`** — was too close to parchment bg, near-invisible |
 | `--link-domain-color-light` | `#8A8070` | **Changed from `#C8C0B4`** — domain text in ExternalLinksBlock (light mode) was unreadable |
 | `--color-text-muted-light` | `#4A5860` | **Changed from `#7A8890`** — navbar links and section meta on parchment bg were below WCAG AA |

--- a/antipratik-ui/src/styles/tokens.css
+++ b/antipratik-ui/src/styles/tokens.css
@@ -366,7 +366,7 @@
 /* ═══════════════════════════════════════════════
    NEWSLETTER BLOCK
 ═══════════════════════════════════════════════ */
---nl-bg:                             #0A0E14;  /* always dark, both modes */
+--nl-bg:                             #0A0E14;  /* fallback only — overridden per theme below */
 --nl-padding-desktop:                64px 32px;
 --nl-padding-mobile:                 48px 24px;
 --nl-border-gradient:                linear-gradient(90deg, transparent 0%, #E03E35 20%, #4A7FBB 40%, #D4A832 60%, #5E9E6A 80%, transparent 100%);
@@ -466,6 +466,9 @@
   --card-border:                     var(--card-border-dark);
   --card-hover-bg:                   var(--card-hover-bg-dark);
   --card-hover-border:               var(--card-hover-border-dark);
+  --nl-bg:                           var(--color-surface-dark);    /* #181D28 — raised surface, visible against page bg #0F1118 */
+  --nl-input-bg:                     var(--color-bg-dark);          /* #0F1118 — inputs darker than block = inset feel */
+  --nl-legal-color:                  var(--color-text-muted-dark);  /* #7A9AB4 — WCAG AA 5.9:1 on new block bg */
 }
 
 /* ═══════════════════════════════════════════════
@@ -489,4 +492,6 @@
   --card-border:                     var(--card-border-light);
   --card-hover-bg:                   var(--card-hover-bg-light);
   --card-hover-border:               var(--card-hover-border-light);
+  --nl-bg:                           var(--color-stone);            /* #1C2B3A — warmer dark, less jarring on parchment */
+  --nl-legal-color:                  var(--color-text-muted-dark);  /* #7A9AB4 — WCAG AA 4.9:1 on new block bg */
 }


### PR DESCRIPTION
The newsletter block used #0A0E14 for both modes: in dark mode this was nearly identical to the page background (#0F1118), causing it to blend in; in light mode the near-black was jarring against the parchment. Added per-theme overrides in the [data-theme] blocks — dark mode now uses --color-surface-dark (#181D28) to create a raised-surface appearance, light mode uses --color-stone (#1C2B3A) for a warmer, softer dark. Updated --nl-input-bg and --nl-legal-color accordingly to maintain WCAG AA contrast.