### PR TITLE
Normalize tag architecture and add tag browsing UI

### DIFF
--- a/app/antipratik-api/api/interface.go
+++ b/app/antipratik-api/api/interface.go
@@ -8,6 +8,7 @@ import "net/http"
 type PostHandler interface {
 	GetPosts(w http.ResponseWriter, r *http.Request)
 	GetPost(w http.ResponseWriter, r *http.Request)
+	GetTags(w http.ResponseWriter, r *http.Request)
 	CreateEssay(w http.ResponseWriter, r *http.Request)
 	CreateShort(w http.ResponseWriter, r *http.Request)
 	CreateMusic(w http.ResponseWriter, r *http.Request)

--- a/app/antipratik-api/api/posts.go
+++ b/app/antipratik-api/api/posts.go
@@ -42,6 +42,16 @@ func (h *PostHandlerImpl) GetPosts(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, posts)
 }
 
+// GetTags handles GET /api/tags — returns all tag names sorted alphabetically.
+func (h *PostHandlerImpl) GetTags(w http.ResponseWriter, r *http.Request) {
+	tags, err := h.logic.GetTags(r.Context())
+	if err != nil {
+		handleLogicError(w, h.log, "GetTags", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tags)
+}
+
 // GetPost handles GET /api/posts/{slug}
 func (h *PostHandlerImpl) GetPost(w http.ResponseWriter, r *http.Request) {
 	slug := r.PathValue("slug")

--- a/app/antipratik-api/db/migrations/008_tags_table.sql
+++ b/app/antipratik-api/db/migrations/008_tags_table.sql
@@ -1,0 +1,41 @@
+-- Step 1: Create normalized tags table
+CREATE TABLE IF NOT EXISTS tags (
+    id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+-- Step 2: Populate tags from existing post_tags strings
+INSERT OR IGNORE INTO tags (name) SELECT DISTINCT tag FROM post_tags;
+
+-- Step 3: Save existing associations into a temp table before dropping post_tags
+CREATE TEMP TABLE post_tags_backup AS
+SELECT post_id, tag FROM post_tags;
+
+-- Step 4: Drop old post_tags table entirely
+DROP TABLE post_tags;
+
+-- Step 5: Recreate post_tags with normalized tag_id FK
+CREATE TABLE post_tags (
+    post_id TEXT    NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+CREATE INDEX idx_post_tags_post_id ON post_tags(post_id);
+CREATE INDEX idx_post_tags_tag_id  ON post_tags(tag_id);
+
+-- Step 6: Re-insert associations using the new tag IDs
+INSERT INTO post_tags (post_id, tag_id)
+SELECT b.post_id, t.id
+FROM post_tags_backup b
+JOIN tags t ON t.name = b.tag;
+
+DROP TABLE post_tags_backup;
+
+-- Step 7: Trigger to clean up orphan tags when a post is deleted
+CREATE TRIGGER IF NOT EXISTS delete_orphan_tags
+AFTER DELETE ON post_tags
+BEGIN
+    DELETE FROM tags
+    WHERE id = OLD.tag_id
+      AND NOT EXISTS (SELECT 1 FROM post_tags WHERE tag_id = OLD.tag_id);
+END;

--- a/app/antipratik-api/logic/interface.go
+++ b/app/antipratik-api/logic/interface.go
@@ -13,6 +13,9 @@ type PostLogic interface {
 	// GetPosts returns posts matching the given filter, newest first.
 	GetPosts(ctx context.Context, filter models.FilterState) ([]models.Post, error)
 
+	// GetTags returns all tag names sorted alphabetically.
+	GetTags(ctx context.Context) ([]string, error)
+
 	// GetPost returns the essay with the given slug, or nil if not found.
 	GetPost(ctx context.Context, slug string) (*models.EssayPost, error)
 

--- a/app/antipratik-api/logic/posts.go
+++ b/app/antipratik-api/logic/posts.go
@@ -47,6 +47,11 @@ func (s *PostService) GetPosts(ctx context.Context, filter models.FilterState) (
 	return posts, nil
 }
 
+// GetTags returns all tag names sorted alphabetically.
+func (s *PostService) GetTags(ctx context.Context) ([]string, error) {
+	return s.store.GetAllTags(ctx)
+}
+
 // GetPost validates the slug and delegates to the store.
 // Returns nil if the post does not exist.
 func (s *PostService) GetPost(ctx context.Context, slug string) (*models.EssayPost, error) {

--- a/app/antipratik-api/routes.go
+++ b/app/antipratik-api/routes.go
@@ -33,6 +33,7 @@ func RegisterRoutes(
 	// Public read routes
 	mux.HandleFunc("GET /api/posts/{slug}", postH.GetPost)
 	mux.HandleFunc("GET /api/posts", postH.GetPosts)
+	mux.HandleFunc("GET /api/tags", postH.GetTags)
 	mux.HandleFunc("GET /api/links/featured", linkH.GetFeaturedLinks)
 	mux.HandleFunc("GET /api/links", linkH.GetLinks)
 

--- a/app/antipratik-api/store/interface.go
+++ b/app/antipratik-api/store/interface.go
@@ -36,6 +36,9 @@ type PostStore interface {
 	UpdateLinkPost(ctx context.Context, id string, input models.LinkPostInput) error
 	DeletePost(ctx context.Context, id string) error
 
+	// GetAllTags returns all tag names sorted alphabetically.
+	GetAllTags(ctx context.Context) ([]string, error)
+
 	// Individual photo image operations
 	AddPhotoImage(ctx context.Context, postID string, image models.PhotoImage) (*models.PhotoImage, error)
 	GetPhotoImage(ctx context.Context, postID string, imageID int) (*models.PhotoImage, error)

--- a/app/antipratik-api/store/posts.go
+++ b/app/antipratik-api/store/posts.go
@@ -18,8 +18,15 @@ func (s *SQLitePostStore) CreatePost(ctx context.Context, postType string, id st
 
 func (s *SQLitePostStore) insertTags(ctx context.Context, tx *sql.Tx, id string, tags []string) error {
 	for _, tag := range tags {
-		_, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO post_tags (post_id, tag) VALUES (?, ?)`, id, tag)
-		if err != nil {
+		// Upsert tag into the normalized tags table.
+		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO tags (name) VALUES (?)`, tag); err != nil {
+			return err
+		}
+		var tagID int64
+		if err := tx.QueryRowContext(ctx, `SELECT id FROM tags WHERE name = ?`, tag).Scan(&tagID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO post_tags (post_id, tag_id) VALUES (?, ?)`, id, tagID); err != nil {
 			return err
 		}
 	}
@@ -438,11 +445,8 @@ func (s *SQLitePostStore) queryBaseRows(ctx context.Context, types, tags []strin
 	var args []any
 
 	if len(tags) > 0 {
-		sb.WriteString("SELECT DISTINCT p.id, p.type, p.created_at FROM posts p JOIN post_tags pt ON p.id = pt.post_id")
+		sb.WriteString("SELECT DISTINCT p.id, p.type, p.created_at FROM posts p JOIN post_tags pt ON p.id = pt.post_id JOIN tags t ON t.id = pt.tag_id")
 	} else {
-		sb.WriteString("SELECT id, p_alias.type, p_alias.created_at FROM posts p_alias")
-		// rewrite to avoid aliasing issue — use plain
-		sb.Reset()
 		sb.WriteString("SELECT id, type, created_at FROM posts")
 	}
 
@@ -458,7 +462,7 @@ func (s *SQLitePostStore) queryBaseRows(ctx context.Context, types, tags []strin
 		}
 	}
 	if len(tags) > 0 {
-		conditions = append(conditions, "pt.tag IN ("+placeholders(len(tags))+")")
+		conditions = append(conditions, "t.name IN ("+placeholders(len(tags))+")")
 		for _, t := range tags {
 			args = append(args, t)
 		}
@@ -492,7 +496,7 @@ func (s *SQLitePostStore) fetchTagsMap(ctx context.Context, ids []string) (map[s
 	if len(ids) == 0 {
 		return map[string][]string{}, nil
 	}
-	q := "SELECT post_id, tag FROM post_tags WHERE post_id IN (" + placeholders(len(ids)) + ") ORDER BY post_id"
+	q := "SELECT pt.post_id, t.name FROM post_tags pt JOIN tags t ON t.id = pt.tag_id WHERE pt.post_id IN (" + placeholders(len(ids)) + ") ORDER BY pt.post_id"
 	args := stringsToAny(ids)
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -507,6 +511,28 @@ func (s *SQLitePostStore) fetchTagsMap(ctx context.Context, ids []string) (map[s
 			return nil, fmt.Errorf("fetchTagsMap scan: %w", err)
 		}
 		result[postID] = append(result[postID], tag)
+	}
+	return result, rows.Err()
+}
+
+// GetAllTags returns all tag names sorted alphabetically.
+func (s *SQLitePostStore) GetAllTags(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name FROM tags ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllTags: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("GetAllTags scan: %w", err)
+		}
+		result = append(result, name)
+	}
+	if result == nil {
+		result = []string{}
 	}
 	return result, rows.Err()
 }

--- a/app/antipratik-ui/CLAUDE.md
+++ b/app/antipratik-ui/CLAUDE.md
@@ -380,6 +380,9 @@ ThemeProvider
 14. **Link essays to `/post/${slug}`** — correct path is `/${slug}`. Next.js catch-all handles it.
 15. **Use `--accent-*` colors on UI chrome elements** — accent tokens are for content only.
 16. **Set text color tokens below minimum contrast** — all text tokens must achieve ≥ 4.5:1 (WCAG AA normal text) or ≥ 3:1 (large/bold text) against their expected background. "Subtle" is for de-emphasis, not invisibility. Verify contrast before changing any `--color-text-*`, `--link-*-color`, or `--nl-*-color` token.
+17. **Manipulate theme-sensitive DOM attributes directly in effects** — use React state instead. `barRef.current.setAttribute('data-mode', …)` is overwritten on the next React re-render. Drive `data-mode` (and similar) via `useState` + `useLayoutEffect` → `setMode(…)` so the value survives re-renders.
+18. **Write critical CSS (e.g. navbar background) only under `[data-theme]` selectors** — if `data-theme` is ever absent, the element is unstyled. Always put the dark-mode default directly on the base selector; light mode overrides with `[data-theme='light']`.
+19. **Define a component-level `transition` that omits properties transitioned by the global `*` catch-all** — if a component declares its own `transition`, it overrides the globals.css catch-all entirely. Any property not listed (e.g. `border-color`) will snap instantly on theme switch. Always include every property that needs to animate.
 
 ---
 

--- a/app/antipratik-ui/src/app/feed/page.tsx
+++ b/app/antipratik-ui/src/app/feed/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { getPosts } from '../../lib/api';
+import { getPosts, getTags } from '../../lib/api';
 import FeedPageClient from '../../components/FeedPageClient/FeedPageClient';
 
 export const dynamic = 'force-dynamic';
@@ -8,7 +8,12 @@ export const metadata: Metadata = {
   title: 'Feed — antipratik',
 };
 
-export default async function FeedPage() {
-  const posts = await getPosts();
-  return <FeedPageClient posts={posts} />;
+interface Props {
+  searchParams: Promise<{ tag?: string }>;
+}
+
+export default async function FeedPage({ searchParams }: Props) {
+  const { tag } = await searchParams;
+  const [posts, allTags] = await Promise.all([getPosts(), getTags()]);
+  return <FeedPageClient posts={posts} allTags={allTags} initialTag={tag} />;
 }

--- a/app/antipratik-ui/src/components/ArticleClient/ArticleClient.module.css
+++ b/app/antipratik-ui/src/components/ArticleClient/ArticleClient.module.css
@@ -177,6 +177,38 @@
   opacity: 0.5;
 }
 
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--space-2);
+}
+
+.tagLink {
+  font-family: var(--font-sans);
+  font-size: var(--text-meta);
+  color: var(--color-text-muted-dark);
+  text-decoration: none;
+  opacity: 0.8;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--motion-fast), opacity var(--motion-fast);
+  }
+}
+
+.tagLink:hover {
+  color: var(--pill-text-essays-dark);
+  opacity: 1;
+}
+
+[data-theme='light'] .tagLink {
+  color: var(--color-text-muted-light);
+}
+
+[data-theme='light'] .tagLink:hover {
+  color: var(--pill-text-essays-light);
+}
+
 /* ── Article body (markdown prose) ─────────────────────────────────────── */
 
 .body {

--- a/app/antipratik-ui/src/components/ArticleClient/ArticleClient.tsx
+++ b/app/antipratik-ui/src/components/ArticleClient/ArticleClient.tsx
@@ -95,6 +95,19 @@ export default function ArticleClient({ post }: Props) {
             <span className={styles.dot}>·</span>
             <span>{post.readingTimeMinutes} min read</span>
           </div>
+          {post.tags.length > 0 && (
+            <div className={styles.tags}>
+              {post.tags.map((tag) => (
+                <Link
+                  key={tag}
+                  href={`/feed?tag=${encodeURIComponent(tag)}`}
+                  className={styles.tagLink}
+                >
+                  #{tag}
+                </Link>
+              ))}
+            </div>
+          )}
         </header>
 
         <div

--- a/app/antipratik-ui/src/components/FeedPageClient/FeedPageClient.tsx
+++ b/app/antipratik-ui/src/components/FeedPageClient/FeedPageClient.tsx
@@ -16,20 +16,17 @@ import styles from './FeedPageClient.module.css';
 
 interface Props {
   posts: Post[];
+  allTags: string[];
+  initialTag?: string;
 }
 
-export default function FeedPageClient({ posts }: Props) {
-  const [state, dispatch] = useReducer(filterReducer, initialFilterState);
-
-  const allTags = useMemo(() => {
-    const tagSet = new Set<string>();
-    for (const post of posts) {
-      for (const tag of post.tags) {
-        tagSet.add(tag);
-      }
-    }
-    return Array.from(tagSet).sort();
-  }, [posts]);
+export default function FeedPageClient({ posts, allTags, initialTag }: Props) {
+  const [state, dispatch] = useReducer(
+    filterReducer,
+    initialTag
+      ? { ...initialFilterState, activeTags: [initialTag] }
+      : initialFilterState,
+  );
 
   const filteredPosts = useMemo(
     () => applyFilters(posts, state),

--- a/app/antipratik-ui/src/components/FilterBar/FilterBar.module.css
+++ b/app/antipratik-ui/src/components/FilterBar/FilterBar.module.css
@@ -133,6 +133,89 @@
   color: var(--color-snow) !important;
 }
 
+/* ─── Tag dropdown ────────────────────────────── */
+
+.tagDropdownWrap {
+  position: relative;
+}
+
+.tagDropdownBtn {
+  margin-left: 4px;
+}
+
+.tagDropdownBtnActive {
+  background: var(--pill-hover-bg-dark);
+}
+
+.bar[data-mode="light"] .tagDropdownBtnActive {
+  background: var(--pill-hover-bg-light);
+}
+
+.tagDropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  background: var(--color-surface-dark);
+  border: var(--filter-bar-border-dark);
+  border-radius: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+  min-width: 140px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.bar[data-mode="light"] .tagDropdown {
+  background: var(--color-canvas-light);
+  border: var(--filter-bar-border-light);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.tagOption {
+  font-family: var(--font-sans);
+  font-size: var(--text-meta);
+  text-align: left;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: none;
+  color: var(--color-text-muted-dark);
+  white-space: nowrap;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: background var(--motion-fast), color var(--motion-fast);
+  }
+}
+
+.tagOption:hover {
+  background: var(--pill-hover-bg-dark);
+  color: var(--color-text-body-dark);
+}
+
+.bar[data-mode="light"] .tagOption {
+  color: var(--color-text-muted-light);
+}
+
+.bar[data-mode="light"] .tagOption:hover {
+  background: var(--pill-hover-bg-light);
+  color: var(--color-text-body-light);
+}
+
+.tagOptionSelected {
+  color: var(--color-snow) !important;
+  background: var(--color-elevated-dark);
+}
+
+.bar[data-mode="light"] .tagOptionSelected {
+  background: var(--color-border-light);
+  color: var(--color-text-body-light) !important;
+}
+
 /* ─── Active tags row ─────────────────────────── */
 
 .tagsRow {

--- a/app/antipratik-ui/src/components/FilterBar/FilterBar.module.css
+++ b/app/antipratik-ui/src/components/FilterBar/FilterBar.module.css
@@ -140,39 +140,154 @@
 }
 
 .tagDropdownBtn {
-  margin-left: 4px;
+  border-radius: 6px;
+  background: var(--color-border-dark);
+  color: var(--color-snow) !important;
+  border-color: transparent;
+  gap: 6px;
+}
+
+.tagDropdownBtn:hover {
+  background: var(--color-text-muted-dark) !important;
 }
 
 .tagDropdownBtnActive {
-  background: var(--pill-hover-bg-dark);
+  background: var(--color-text-muted-dark) !important;
+  color: var(--color-snow) !important;
+}
+
+.bar[data-mode="light"] .tagDropdownBtn {
+  background: var(--color-border-light);
+  color: var(--color-ink-light) !important;
+}
+
+.bar[data-mode="light"] .tagDropdownBtn:hover {
+  background: var(--color-text-muted-light) !important;
+  color: var(--color-snow) !important;
 }
 
 .bar[data-mode="light"] .tagDropdownBtnActive {
-  background: var(--pill-hover-bg-light);
+  background: var(--color-text-muted-light) !important;
+  color: var(--color-snow) !important;
+}
+
+.tagDropdownArrow {
+  font-size: 12px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
+@keyframes tagDropdownIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes tagDropdownOut {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-6px); }
 }
 
 .tagDropdown {
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  z-index: 10;
+  /* position: fixed so top/left come from JS getBoundingClientRect —
+     dropdown is always within the viewport, never clips or scrolls the page */
+  position: fixed;
+  z-index: 200;
+  width: 160px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 6px;
   background: var(--color-surface-dark);
   border: var(--filter-bar-border-dark);
   border-radius: 8px;
-  max-height: 200px;
-  overflow-y: auto;
   min-width: 140px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  animation: tagDropdownIn 200ms ease-out forwards;
+}
+
+.tagDropdownClosing {
+  animation: tagDropdownOut 200ms ease-in forwards;
 }
 
 .bar[data-mode="light"] .tagDropdown {
   background: var(--color-canvas-light);
   border: var(--filter-bar-border-light);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+
+
+.tagDropdownList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  /* smooth momentum scroll on iOS */
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  /* hide native scrollbar everywhere — replaced by arrow buttons */
+  scrollbar-width: none;
+}
+
+.tagDropdownList::-webkit-scrollbar {
+  display: none;
+}
+
+/* Scroll arrow buttons — shown when list content overflows in that direction.
+   Rendered as a translucent gradient fade so they blend into the dropdown bg. */
+.mobileScrollArrow {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 28px;
+  border: none;
+  cursor: pointer;
+  font-size: 9px;
+  line-height: 1;
+  /* Transparent bg with gradient so it feels like a fade, not a hard button */
+  background: transparent;
+  color: var(--color-text-muted-dark);
+  flex-shrink: 0;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--motion-fast);
+  }
+}
+
+.mobileScrollArrow:hover,
+.mobileScrollArrow:active {
+  color: var(--color-snow);
+}
+
+.bar[data-mode="light"] .mobileScrollArrow {
+  color: var(--color-text-muted-light);
+}
+
+.bar[data-mode="light"] .mobileScrollArrow:hover,
+.bar[data-mode="light"] .mobileScrollArrow:active {
+  color: var(--color-ink-light);
+}
+
+/* Gradient fade — translucent so tags are faintly visible behind the arrow.
+   rgba() used because custom properties can't carry an alpha channel here.
+   Source tokens: --color-surface-dark (#181D28), --color-canvas-light (#EDEAE2) */
+.mobileScrollArrowUp {
+  background: linear-gradient(to bottom, rgba(24, 29, 40, 0.9), rgba(24, 29, 40, 0));
+}
+
+.mobileScrollArrowDown {
+  background: linear-gradient(to top, rgba(24, 29, 40, 0.9), rgba(24, 29, 40, 0));
+}
+
+.bar[data-mode="light"] .mobileScrollArrowUp {
+  background: linear-gradient(to bottom, rgba(237, 234, 226, 0.9), rgba(237, 234, 226, 0));
+}
+
+.bar[data-mode="light"] .mobileScrollArrowDown {
+  background: linear-gradient(to top, rgba(237, 234, 226, 0.9), rgba(237, 234, 226, 0));
 }
 
 .tagOption {
@@ -223,6 +338,7 @@
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
+  padding: 4px 0;
 }
 
 .chip {
@@ -258,17 +374,34 @@
   color: var(--color-text-muted-light);
 }
 
-.clearTags {
-  background: none;
-  border: none;
-  cursor: pointer;
+.clearTagsDropdown {
   font-family: var(--font-sans);
   font-size: var(--text-meta);
+  text-align: left;
+  padding: 5px 10px;
+  border: none;
+  border-top: 0.5px solid var(--color-border-dark);
+  border-radius: 0;
+  cursor: pointer;
+  background: none;
   color: var(--color-text-muted-dark);
-  padding: 0;
-  margin-left: auto;
+  margin-top: 4px;
+  width: 100%;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--motion-fast);
+  }
 }
 
-.bar[data-mode="light"] .clearTags {
+.clearTagsDropdown:hover {
+  color: var(--color-snow);
+}
+
+.bar[data-mode="light"] .clearTagsDropdown {
+  border-top-color: var(--color-border-light);
   color: var(--color-text-muted-light);
+}
+
+.bar[data-mode="light"] .clearTagsDropdown:hover {
+  color: var(--color-ink-light);
 }

--- a/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
+++ b/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
@@ -22,7 +22,11 @@ const CONTENT_TYPES: { type: ContentType; label: string; pillClass: string }[] =
 const SCROLL_STEP = 80;
 
 export default function FilterBar({ state, allTags, dispatch }: Props) {
-  const barRef = useRef<HTMLDivElement>(null);
+  // 'dark' is the SSR-safe default — useLayoutEffect syncs to data-theme before
+  // the browser paints, so light-mode users never see a flash. Driving data-mode
+  // from React state (rather than direct setAttribute) means React re-renders
+  // can never reset the attribute back to the hardcoded JSX value.
+  const [mode, setMode] = useState<'dark' | 'light'>('dark');
   const dropdownRef = useRef<HTMLDivElement>(null);
   const dropdownElRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -31,6 +35,18 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+
+  // Sync mode with data-theme on <html> (Rule 5). Using setMode keeps
+  // data-mode React-controlled so re-renders never reset it to "dark".
+  useLayoutEffect(() => {
+    function sync() {
+      setMode((document.documentElement.getAttribute('data-theme') as 'dark' | 'light') ?? 'dark');
+    }
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
 
   const ANIMATION_DURATION = 200;
 
@@ -41,18 +57,6 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
       setIsClosing(false);
     }, ANIMATION_DURATION);
   }
-
-  // Mirror data-theme on <html> to data-mode on this element (Rule 5)
-  useLayoutEffect(() => {
-    function sync() {
-      const theme = document.documentElement.getAttribute('data-theme') ?? 'dark';
-      barRef.current?.setAttribute('data-mode', theme);
-    }
-    sync();
-    const observer = new MutationObserver(sync);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-    return () => observer.disconnect();
-  }, []);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -119,7 +123,7 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
   }
 
   return (
-    <div ref={barRef} className={styles.bar} data-mode="dark">
+    <div className={styles.bar} data-mode={mode}>
       <div className={styles.pillsRow}>
         <button
           className={`${styles.pill} ${styles.pillAll}${state.activeTypes.length === 0 ? ` ${styles.selected}` : ''}`}

--- a/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
+++ b/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useRef } from 'react';
+import { useLayoutEffect, useRef, useState, useEffect } from 'react';
 import type { FilterState, FilterAction, ContentType } from '../../lib/types';
 import styles from './FilterBar.module.css';
 
@@ -19,8 +19,10 @@ const CONTENT_TYPES: { type: ContentType; label: string; pillClass: string }[] =
   { type: 'link',   label: 'Links',   pillClass: styles.pillLink  },
 ];
 
-export default function FilterBar({ state, allTags: _allTags, dispatch }: Props) {
+export default function FilterBar({ state, allTags, dispatch }: Props) {
   const barRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   // Mirror data-theme on <html> to data-mode on this element (Rule 5)
   // useLayoutEffect fires before paint — prevents dark flash on page navigation
@@ -37,6 +39,18 @@ export default function FilterBar({ state, allTags: _allTags, dispatch }: Props)
     });
     return () => observer.disconnect();
   }, []);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [dropdownOpen]);
 
   return (
     <div ref={barRef} className={styles.bar} data-mode="dark">
@@ -56,6 +70,37 @@ export default function FilterBar({ state, allTags: _allTags, dispatch }: Props)
             {label}
           </button>
         ))}
+
+        {allTags.length > 0 && (
+          <div ref={dropdownRef} className={styles.tagDropdownWrap}>
+            <button
+              className={`${styles.pill} ${styles.pillAll} ${styles.tagDropdownBtn}${state.activeTags.length > 0 ? ` ${styles.tagDropdownBtnActive}` : ''}`}
+              onClick={() => setDropdownOpen((o) => !o)}
+              aria-expanded={dropdownOpen}
+              aria-haspopup="listbox"
+            >
+              Tags{state.activeTags.length > 0 ? ` (${state.activeTags.length})` : ''} {dropdownOpen ? '▴' : '▾'}
+            </button>
+            {dropdownOpen && (
+              <div className={styles.tagDropdown} role="listbox" aria-multiselectable="true">
+                {allTags.map((tag) => {
+                  const selected = state.activeTags.includes(tag);
+                  return (
+                    <button
+                      key={tag}
+                      role="option"
+                      aria-selected={selected}
+                      className={`${styles.tagOption}${selected ? ` ${styles.tagOptionSelected}` : ''}`}
+                      onClick={() => dispatch({ type: 'TOGGLE_TAG', tag })}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {state.activeTags.length > 0 && (

--- a/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
+++ b/app/antipratik-ui/src/components/FilterBar/FilterBar.tsx
@@ -19,13 +19,30 @@ const CONTENT_TYPES: { type: ContentType; label: string; pillClass: string }[] =
   { type: 'link',   label: 'Links',   pillClass: styles.pillLink  },
 ];
 
+const SCROLL_STEP = 80;
+
 export default function FilterBar({ state, allTags, dispatch }: Props) {
   const barRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownElRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null);
+  const [canScrollUp, setCanScrollUp] = useState(false);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  const ANIMATION_DURATION = 200;
+
+  function closeDropdown() {
+    setIsClosing(true);
+    setTimeout(() => {
+      setDropdownOpen(false);
+      setIsClosing(false);
+    }, ANIMATION_DURATION);
+  }
 
   // Mirror data-theme on <html> to data-mode on this element (Rule 5)
-  // useLayoutEffect fires before paint — prevents dark flash on page navigation
   useLayoutEffect(() => {
     function sync() {
       const theme = document.documentElement.getAttribute('data-theme') ?? 'dark';
@@ -33,10 +50,7 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
     }
     sync();
     const observer = new MutationObserver(sync);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
     return () => observer.disconnect();
   }, []);
 
@@ -44,13 +58,65 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
   useEffect(() => {
     if (!dropdownOpen) return;
     function handleClick(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false);
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
+        dropdownElRef.current && !dropdownElRef.current.contains(e.target as Node)
+      ) {
+        closeDropdown();
       }
     }
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [dropdownOpen]);
+
+  // Calculate fixed position for the dropdown — re-runs on open and on window resize
+  // so the dropdown tracks the button even if the viewport changes while open.
+  useEffect(() => {
+    if (!dropdownOpen) return;
+
+    function recalc() {
+      const btn = dropdownRef.current?.querySelector('button');
+      if (!btn) return;
+      const rect = btn.getBoundingClientRect();
+      const DROPDOWN_WIDTH = 160;
+      const MARGIN = 8;
+      let left = rect.left;
+      if (left + DROPDOWN_WIDTH > window.innerWidth - MARGIN) {
+        left = window.innerWidth - DROPDOWN_WIDTH - MARGIN;
+      }
+      setDropdownPos({ top: rect.bottom + 6, left: Math.max(MARGIN, left) });
+    }
+
+    const raf = requestAnimationFrame(recalc);
+    window.addEventListener('resize', recalc);
+    window.addEventListener('scroll', recalc, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', recalc);
+      window.removeEventListener('scroll', recalc);
+    };
+  }, [dropdownOpen]);
+
+  // Update scroll arrow visibility whenever the list scrolls or opens
+  function syncScrollArrows() {
+    const el = listRef.current;
+    if (!el) return;
+    setCanScrollUp(el.scrollTop > 0);
+    setCanScrollDown(el.scrollTop + el.clientHeight < el.scrollHeight - 1);
+  }
+
+  useEffect(() => {
+    if (dropdownOpen) {
+      requestAnimationFrame(syncScrollArrows);
+    }
+  }, [dropdownOpen, allTags]);
+
+  function scrollList(direction: 'up' | 'down') {
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollBy({ top: direction === 'up' ? -SCROLL_STEP : SCROLL_STEP, behavior: 'smooth' });
+  }
 
   return (
     <div ref={barRef} className={styles.bar} data-mode="dark">
@@ -75,28 +141,70 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
           <div ref={dropdownRef} className={styles.tagDropdownWrap}>
             <button
               className={`${styles.pill} ${styles.pillAll} ${styles.tagDropdownBtn}${state.activeTags.length > 0 ? ` ${styles.tagDropdownBtnActive}` : ''}`}
-              onClick={() => setDropdownOpen((o) => !o)}
+              onClick={() => dropdownOpen ? closeDropdown() : setDropdownOpen(true)}
               aria-expanded={dropdownOpen}
               aria-haspopup="listbox"
             >
-              Tags{state.activeTags.length > 0 ? ` (${state.activeTags.length})` : ''} {dropdownOpen ? '▴' : '▾'}
+              Tags{state.activeTags.length > 0 ? ` (${state.activeTags.length})` : ''}
+              <span className={styles.tagDropdownArrow} aria-hidden="true">{(dropdownOpen || isClosing) ? '▲' : '▼'}</span>
             </button>
-            {dropdownOpen && (
-              <div className={styles.tagDropdown} role="listbox" aria-multiselectable="true">
-                {allTags.map((tag) => {
-                  const selected = state.activeTags.includes(tag);
-                  return (
-                    <button
-                      key={tag}
-                      role="option"
-                      aria-selected={selected}
-                      className={`${styles.tagOption}${selected ? ` ${styles.tagOptionSelected}` : ''}`}
-                      onClick={() => dispatch({ type: 'TOGGLE_TAG', tag })}
-                    >
-                      {tag}
-                    </button>
-                  );
-                })}
+            {(dropdownOpen || isClosing) && dropdownPos && (
+              <div
+                ref={dropdownElRef}
+                className={`${styles.tagDropdown}${isClosing ? ` ${styles.tagDropdownClosing}` : ''}`}
+                style={{ top: dropdownPos.top, left: dropdownPos.left }}
+              >
+                {/* Mobile-only scroll up arrow */}
+                {canScrollUp && (
+                  <button
+                    className={`${styles.mobileScrollArrow} ${styles.mobileScrollArrowUp}`}
+                    onClick={() => scrollList('up')}
+                    aria-label="Scroll tags up"
+                  >
+                    ▲
+                  </button>
+                )}
+                <div
+                  ref={listRef}
+                  role="listbox"
+                  aria-multiselectable="true"
+                  className={styles.tagDropdownList}
+                  onScroll={syncScrollArrows}
+                >
+                  {allTags.map((tag) => {
+                    const selected = state.activeTags.includes(tag);
+                    return (
+                      <button
+                        key={tag}
+                        role="option"
+                        aria-selected={selected}
+                        className={`${styles.tagOption}${selected ? ` ${styles.tagOptionSelected}` : ''}`}
+                        onClick={() => dispatch({ type: 'TOGGLE_TAG', tag })}
+                      >
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+                {/* Scroll down arrow — shown when list has more content below */}
+                {canScrollDown && (
+                  <button
+                    className={`${styles.mobileScrollArrow} ${styles.mobileScrollArrowDown}`}
+                    onClick={() => scrollList('down')}
+                    aria-label="Scroll tags down"
+                  >
+                    ▼
+                  </button>
+                )}
+                {/* Clear tags — always pinned at bottom, outside scroll area */}
+                {state.activeTags.length > 0 && (
+                  <button
+                    className={styles.clearTagsDropdown}
+                    onClick={() => dispatch({ type: 'CLEAR_TAGS' })}
+                  >
+                    Clear tags
+                  </button>
+                )}
               </div>
             )}
           </div>
@@ -117,12 +225,6 @@ export default function FilterBar({ state, allTags, dispatch }: Props) {
               </button>
             </span>
           ))}
-          <button
-            className={styles.clearTags}
-            onClick={() => dispatch({ type: 'CLEAR_ALL' })}
-          >
-            Clear all
-          </button>
         </div>
       )}
     </div>

--- a/app/antipratik-ui/src/components/Navbar/Navbar.module.css
+++ b/app/antipratik-ui/src/components/Navbar/Navbar.module.css
@@ -121,7 +121,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .navLink {
-    transition: color var(--motion-theme);
+    transition: color var(--motion-theme), border-color var(--motion-theme);
   }
 }
 
@@ -257,18 +257,17 @@
   color: var(--color-text-muted-light);
 }
 
-/* Dark mode — Himalayan Dusk */
-[data-theme='dark'] .navbar {
+/* Dark mode is the default — keeps navbar opaque even if data-theme is
+   momentarily absent during hydration. Light mode overrides below. */
+.navbar {
   background: var(--nav-bg-dark-blur);
   border-bottom: 0.5px solid var(--color-border-dark);
   backdrop-filter: blur(12px);
 }
 
-/* Light mode — Parchment */
 [data-theme='light'] .navbar {
   background: var(--nav-bg-light-blur);
   border-bottom: 0.5px solid var(--color-border-light);
-  backdrop-filter: blur(12px);
 }
 
 /* ─── Hamburger button ───────────────────────── */

--- a/app/antipratik-ui/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/app/antipratik-ui/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import type { Theme } from '../../lib/types';
 
 interface ThemeContextType {
@@ -17,6 +17,13 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     if (typeof document === 'undefined') return 'dark';
     return (document.documentElement.dataset.theme as Theme) || 'dark';
   });
+
+  // Re-assert data-theme after hydration. The inline script in layout.tsx
+  // sets it before first paint, but React's reconciliation can briefly
+  // remove unknown attributes from <html> in some Next.js versions.
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
 
   const toggle = () => {
     setTheme((prev) => {

--- a/app/antipratik-ui/src/lib/api.ts
+++ b/app/antipratik-ui/src/lib/api.ts
@@ -81,6 +81,23 @@ function prefixPost(post: Post): Post {
 // Pages will render with empty collections, and actual data loading requires
 // NEXT_PUBLIC_API_URL to be configured at runtime.
 
+// ─── TAGS ────────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/tags
+ * Returns all tag names sorted alphabetically.
+ */
+export async function getTags(): Promise<string[]> {
+  if (IS_API_DISABLED) {
+    return [];
+  }
+  const response = await fetch(`${getFetchBase()}/api/tags`, { cache: 'no-store' });
+  if (!response.ok) {
+    return [];
+  }
+  return response.json();
+}
+
 // ─── POSTS ───────────────────────────────────────────────────────────────────
 
 /**

--- a/app/antipratik-ui/src/lib/feed.ts
+++ b/app/antipratik-ui/src/lib/feed.ts
@@ -40,6 +40,8 @@ export function filterReducer(state: FilterState, action: FilterAction): FilterS
       return { ...state, sortOrder: action.order };
     case 'CLEAR_ALL':
       return { activeTypes: [], activeTags: [], sortOrder: 'newest' };
+    case 'CLEAR_TAGS':
+      return { ...state, activeTags: [] };
   }
 }
 

--- a/app/antipratik-ui/src/lib/types.ts
+++ b/app/antipratik-ui/src/lib/types.ts
@@ -140,4 +140,5 @@ export type FilterAction =
   | { type: 'TOGGLE_TYPE'; contentType: ContentType }
   | { type: 'TOGGLE_TAG'; tag: string }
   | { type: 'SET_SORT'; order: FilterState['sortOrder'] }
-  | { type: 'CLEAR_ALL' };
+  | { type: 'CLEAR_ALL' }
+  | { type: 'CLEAR_TAGS' };


### PR DESCRIPTION
Closes #100

## Summary
- **BE – Migration 008**: Introduces a normalized `tags` table (id, name unique), drops and recreates `post_tags` as `(post_id, tag_id)` with FK to `tags`, migrates all existing data, and adds a SQLite trigger to auto-delete orphan tags when a post is deleted
- **BE – GET /api/tags**: New public endpoint returning all tag names sorted alphabetically; wired through store → logic → api → routes following the 3-layer pattern
- **FE – Tag dropdown**: FilterBar now shows a "Tags ▾" button that opens a scrollable dropdown listing all tags from `/api/tags`; selected tags are highlighted and still appear as removable chips below the pills row
- **FE – Essay tags**: Tags appear below the date/reading-time meta in the essay reading view, each linking to `/feed?tag=…` to deep-link into the filtered feed
- **FE – URL pre-selection**: Navigating to `/feed?tag=xxx` (e.g. from an essay tag link) pre-selects that tag on first render

## Scope
FE + BE — both the data model and the UI needed to change together

## Test plan
- [ ] Deploy with existing DB: migration 008 runs, all existing tags preserved in new `tags` table, no data loss
- [ ] `GET /api/tags` returns sorted array of unique tag strings
- [ ] `GET /api/posts?tag=xxx` still filters posts correctly (tag JOIN updated)
- [ ] Delete a post whose tags are not shared → orphan tags removed from `tags` table
- [ ] Delete a post whose tags are shared → shared tags remain
- [ ] Feed page: "Tags ▾" button appears; clicking opens scrollable dropdown; selecting a tag filters posts and shows active chip
- [ ] Navigate to `/feed?tag=xxx` → feed pre-filtered with that tag active
- [ ] Open an essay with tags → tags show below meta, clicking one navigates to `/feed?tag=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)