### PR TITLE
Add ability to update album art, video thumbnail, and link thumbnail

### DIFF
--- a/app/antipratik-api/components/posts/api/posts.go
+++ b/app/antipratik-api/components/posts/api/posts.go
@@ -226,6 +226,33 @@ func (h *postHandler) UpdateMusic(w http.ResponseWriter, r *http.Request) {
 		input.Album = &albumStr
 	}
 
+	if artFile, artHeader, artErr := r.FormFile("albumArtFile"); artErr == nil {
+		defer func() { _ = artFile.Close() }()
+		uploaded, uploadErr := h.uploads.UploadMusicFiles(r.Context(), postID, nil,
+			&files.FileInput{File: artFile, Header: artHeader})
+		if uploadErr != nil {
+			handleLogicError(w, h.log, "UpdateMusic album art upload", uploadErr)
+			return
+		}
+		input.AlbumArt = &uploaded.AlbumArtURL
+		if uploaded.AlbumArtTinyURL != "" {
+			v := uploaded.AlbumArtTinyURL
+			input.AlbumArtTinyURL = &v
+		}
+		if uploaded.AlbumArtSmallURL != "" {
+			v := uploaded.AlbumArtSmallURL
+			input.AlbumArtSmallURL = &v
+		}
+		if uploaded.AlbumArtMedURL != "" {
+			v := uploaded.AlbumArtMedURL
+			input.AlbumArtMedURL = &v
+		}
+		if uploaded.AlbumArtLargeURL != "" {
+			v := uploaded.AlbumArtLargeURL
+			input.AlbumArtLargeURL = &v
+		}
+	}
+
 	post, err := h.logic.UpdateMusic(r.Context(), postID, input)
 	if err != nil {
 		handleLogicError(w, h.log, "UpdateMusic", err)
@@ -401,6 +428,21 @@ func (h *postHandler) UpdateVideo(w http.ResponseWriter, r *http.Request) {
 		input.Playlist = &pl
 	}
 
+	if thumbFile, thumbHeader, thumbErr := r.FormFile("thumbnailFile"); thumbErr == nil {
+		defer func() { _ = thumbFile.Close() }()
+		result, uploadErr := h.uploads.UploadThumbnail(r.Context(), postID, "thumb",
+			files.FileInput{File: thumbFile, Header: thumbHeader})
+		if uploadErr != nil {
+			handleLogicError(w, h.log, "UpdateVideo thumbnail upload", uploadErr)
+			return
+		}
+		input.ThumbnailURL = &result.URL
+		input.ThumbnailTinyURL = &result.TinyURL
+		input.ThumbnailSmallURL = &result.SmallURL
+		input.ThumbnailMedURL = &result.MedURL
+		input.ThumbnailLargeURL = &result.LargeURL
+	}
+
 	post, err := h.logic.UpdateVideo(r.Context(), postID, input)
 	if err != nil {
 		handleLogicError(w, h.log, "UpdateVideo", err)
@@ -477,6 +519,21 @@ func (h *postHandler) UpdateLinkPost(w http.ResponseWriter, r *http.Request) {
 	}
 	if cat := r.FormValue("category"); cat != "" {
 		input.Category = &cat
+	}
+
+	if thumbFile, thumbHeader, thumbErr := r.FormFile("thumbnailFile"); thumbErr == nil {
+		defer func() { _ = thumbFile.Close() }()
+		result, uploadErr := h.uploads.UploadThumbnail(r.Context(), postID, "thumb",
+			files.FileInput{File: thumbFile, Header: thumbHeader})
+		if uploadErr != nil {
+			handleLogicError(w, h.log, "UpdateLinkPost thumbnail upload", uploadErr)
+			return
+		}
+		input.ThumbnailURL = &result.URL
+		input.ThumbnailTinyURL = &result.TinyURL
+		input.ThumbnailSmallURL = &result.SmallURL
+		input.ThumbnailMedURL = &result.MedURL
+		input.ThumbnailLargeURL = &result.LargeURL
 	}
 
 	post, err := h.logic.UpdateLinkPost(r.Context(), postID, input)

--- a/app/antipratik-api/components/posts/logic/posts.go
+++ b/app/antipratik-api/components/posts/logic/posts.go
@@ -375,6 +375,10 @@ func (s *postLogic) UpdateMusic(ctx context.Context, id string, input posts.Upda
 	}
 	if input.AlbumArt != nil {
 		merged.AlbumArt = *input.AlbumArt
+		merged.AlbumArtTinyURL = input.AlbumArtTinyURL
+		merged.AlbumArtSmallURL = input.AlbumArtSmallURL
+		merged.AlbumArtMedURL = input.AlbumArtMedURL
+		merged.AlbumArtLargeURL = input.AlbumArtLargeURL
 	}
 	if input.Album != nil {
 		merged.Album = input.Album
@@ -494,6 +498,13 @@ func (s *postLogic) UpdateVideo(ctx context.Context, id string, input posts.Upda
 	if input.Playlist != nil {
 		merged.Playlist = input.Playlist
 	}
+	if input.ThumbnailURL != nil {
+		merged.ThumbnailURL = *input.ThumbnailURL
+		merged.ThumbnailTinyURL = input.ThumbnailTinyURL
+		merged.ThumbnailSmallURL = input.ThumbnailSmallURL
+		merged.ThumbnailMedURL = input.ThumbnailMedURL
+		merged.ThumbnailLargeURL = input.ThumbnailLargeURL
+	}
 	if input.Tags != nil {
 		merged.Tags = input.Tags
 	}
@@ -573,6 +584,13 @@ func (s *postLogic) UpdateLinkPost(ctx context.Context, id string, input posts.U
 	}
 	if input.Category != nil {
 		merged.Category = input.Category
+	}
+	if input.ThumbnailURL != nil {
+		merged.ThumbnailURL = input.ThumbnailURL
+		merged.ThumbnailTinyURL = input.ThumbnailTinyURL
+		merged.ThumbnailSmallURL = input.ThumbnailSmallURL
+		merged.ThumbnailMedURL = input.ThumbnailMedURL
+		merged.ThumbnailLargeURL = input.ThumbnailLargeURL
 	}
 	if input.Tags != nil {
 		merged.Tags = input.Tags

--- a/app/antipratik-api/components/posts/logic/posts.go
+++ b/app/antipratik-api/components/posts/logic/posts.go
@@ -394,7 +394,7 @@ func (s *postLogic) UpdateMusic(ctx context.Context, id string, input posts.Upda
 	}
 
 	var oldArtKeys []string
-	if input.AlbumArt != nil && cur.AlbumArt != "" {
+	if input.AlbumArt != nil && cur.AlbumArt != "" && cur.AlbumArt != *input.AlbumArt {
 		oldArtKeys = albumArtFileKeys(cur)
 	}
 
@@ -509,7 +509,7 @@ func (s *postLogic) UpdateVideo(ctx context.Context, id string, input posts.Upda
 	}
 
 	var oldThumbKeys []string
-	if input.ThumbnailURL != nil && cur.ThumbnailURL != "" {
+	if input.ThumbnailURL != nil && cur.ThumbnailURL != "" && cur.ThumbnailURL != *input.ThumbnailURL {
 		oldThumbKeys = thumbnailFileKeys(cur.ThumbnailURL, cur.ThumbnailTinyURL, cur.ThumbnailSmallURL, cur.ThumbnailMedURL, cur.ThumbnailLargeURL)
 	}
 
@@ -591,7 +591,7 @@ func (s *postLogic) UpdateLinkPost(ctx context.Context, id string, input posts.U
 	merged.Domain = domain
 
 	var oldThumbKeys []string
-	if input.ThumbnailURL != nil && cur.ThumbnailURL != nil && *cur.ThumbnailURL != "" {
+	if input.ThumbnailURL != nil && cur.ThumbnailURL != nil && *cur.ThumbnailURL != "" && *cur.ThumbnailURL != *input.ThumbnailURL {
 		oldThumbKeys = thumbnailFileKeys(*cur.ThumbnailURL, cur.ThumbnailTinyURL, cur.ThumbnailSmallURL, cur.ThumbnailMedURL, cur.ThumbnailLargeURL)
 	}
 

--- a/app/antipratik-api/components/posts/logic/posts.go
+++ b/app/antipratik-api/components/posts/logic/posts.go
@@ -393,8 +393,25 @@ func (s *postLogic) UpdateMusic(ctx context.Context, id string, input posts.Upda
 		return posts.MusicPost{}, err
 	}
 
+	var oldArtKeys []string
+	if input.AlbumArt != nil && cur.AlbumArt != "" {
+		oldArtKeys = albumArtFileKeys(cur)
+	}
+
 	if err := s.store.UpdateMusic(ctx, id, merged); err != nil {
 		return posts.MusicPost{}, fmt.Errorf("postLogic.UpdateMusic: %w", err)
+	}
+
+	if len(oldArtKeys) > 0 {
+		log := s.log
+		files := s.files
+		go func() {
+			for _, key := range oldArtKeys {
+				if err := files.Delete(context.Background(), key); err != nil {
+					log.Error("UpdateMusic: failed to delete old album art", "key", key, "err", err)
+				}
+			}
+		}()
 	}
 
 	tags := merged.Tags
@@ -491,8 +508,25 @@ func (s *postLogic) UpdateVideo(ctx context.Context, id string, input posts.Upda
 		return posts.VideoPost{}, err
 	}
 
+	var oldThumbKeys []string
+	if input.ThumbnailURL != nil && cur.ThumbnailURL != "" {
+		oldThumbKeys = thumbnailFileKeys(cur.ThumbnailURL, cur.ThumbnailTinyURL, cur.ThumbnailSmallURL, cur.ThumbnailMedURL, cur.ThumbnailLargeURL)
+	}
+
 	if err := s.store.UpdateVideo(ctx, id, merged); err != nil {
 		return posts.VideoPost{}, fmt.Errorf("postLogic.UpdateVideo: %w", err)
+	}
+
+	if len(oldThumbKeys) > 0 {
+		log := s.log
+		files := s.files
+		go func() {
+			for _, key := range oldThumbKeys {
+				if err := files.Delete(context.Background(), key); err != nil {
+					log.Error("UpdateVideo: failed to delete old thumbnail", "key", key, "err", err)
+				}
+			}
+		}()
 	}
 
 	tags := merged.Tags
@@ -556,8 +590,25 @@ func (s *postLogic) UpdateLinkPost(ctx context.Context, id string, input posts.U
 	}
 	merged.Domain = domain
 
+	var oldThumbKeys []string
+	if input.ThumbnailURL != nil && cur.ThumbnailURL != nil && *cur.ThumbnailURL != "" {
+		oldThumbKeys = thumbnailFileKeys(*cur.ThumbnailURL, cur.ThumbnailTinyURL, cur.ThumbnailSmallURL, cur.ThumbnailMedURL, cur.ThumbnailLargeURL)
+	}
+
 	if err = s.store.UpdateLinkPost(ctx, id, merged); err != nil {
 		return posts.LinkPost{}, fmt.Errorf("postLogic.UpdateLinkPost: %w", err)
+	}
+
+	if len(oldThumbKeys) > 0 {
+		log := s.log
+		files := s.files
+		go func() {
+			for _, key := range oldThumbKeys {
+				if err := files.Delete(context.Background(), key); err != nil {
+					log.Error("UpdateLinkPost: failed to delete old thumbnail", "key", key, "err", err)
+				}
+			}
+		}()
 	}
 	tags := merged.Tags
 	if tags == nil {

--- a/app/antipratik-api/components/posts/logic/utils.go
+++ b/app/antipratik-api/components/posts/logic/utils.go
@@ -73,6 +73,34 @@ func fileKeysForImage(img *posts.PhotoImage) []string {
 	return keys
 }
 
+// albumArtFileKeys returns all storage keys for a MusicPost's album art (original + 4 sizes).
+func albumArtFileKeys(p posts.MusicPost) []string {
+	var keys []string
+	if p.AlbumArt != "" {
+		keys = append(keys, urlToStorageKey(p.AlbumArt))
+	}
+	for _, u := range []*string{p.AlbumArtTinyURL, p.AlbumArtSmallURL, p.AlbumArtMedURL, p.AlbumArtLargeURL} {
+		if u != nil && *u != "" {
+			keys = append(keys, urlToStorageKey(*u))
+		}
+	}
+	return keys
+}
+
+// thumbnailFileKeys returns all storage keys for a thumbnail set (original + 4 sizes).
+func thumbnailFileKeys(url string, tiny, small, med, large *string) []string {
+	var keys []string
+	if url != "" {
+		keys = append(keys, urlToStorageKey(url))
+	}
+	for _, u := range []*string{tiny, small, med, large} {
+		if u != nil && *u != "" {
+			keys = append(keys, urlToStorageKey(*u))
+		}
+	}
+	return keys
+}
+
 // urlToStorageKey converts a serving URL (/files/<id> or /thumbnails/<id>)
 // to a storage key (photos/<id>, music/<id>, or thumbnails/<id>).
 func urlToStorageKey(u string) string {

--- a/app/antipratik-ui/src/components/Admin/LinkForm/LinkForm.tsx
+++ b/app/antipratik-ui/src/components/Admin/LinkForm/LinkForm.tsx
@@ -38,6 +38,7 @@ export default function LinkForm({ token, initial, onSuccess, onCancel }: LinkFo
         if (url !== initial.url) fd.append('url', url);
         if (description !== (initial.description ?? '')) fd.append('description', description);
         if (category && category !== initial.category) fd.append('category', category);
+        if (thumbnailFile) fd.append('thumbnailFile', thumbnailFile);
         tags.forEach((t) => fd.append('tags[]', t));
         await updateLinkPost(initial.id, fd, token);
       } else {
@@ -87,14 +88,9 @@ export default function LinkForm({ token, initial, onSuccess, onCancel }: LinkFo
       </div>
 
       <div className={f.field}>
-        <label className={f.label} htmlFor="link-thumb">
-          Thumbnail {initial && <span className={f.immutableNote}>(cannot be changed after creation)</span>}
-        </label>
-        {initial ? (
-          <p className={f.immutableNote}>Current: {initial.thumbnailUrl || 'none'}</p>
-        ) : (
-          <input id="link-thumb" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setThumbnailFile(e.target.files?.[0] ?? null)} disabled={loading} />
-        )}
+        <label className={f.label} htmlFor="link-thumb">Thumbnail</label>
+        {initial && <p className={f.immutableNote}>Current: {initial.thumbnailUrl || 'none'}</p>}
+        <input id="link-thumb" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setThumbnailFile(e.target.files?.[0] ?? null)} disabled={loading} />
       </div>
 
       <div className={f.field}>

--- a/app/antipratik-ui/src/components/Admin/MusicForm/MusicForm.tsx
+++ b/app/antipratik-ui/src/components/Admin/MusicForm/MusicForm.tsx
@@ -49,6 +49,7 @@ export default function MusicForm({ token, initial, onSuccess, onCancel }: Music
       if (initial) {
         if (title !== initial.title) fd.append('title', title);
         if (album !== (initial.album ?? '')) fd.append('album', album);
+        if (albumArtFile) fd.append('albumArtFile', albumArtFile);
         tags.forEach((t) => fd.append('tags[]', t));
         await updateMusicPost(initial.id, fd, token);
       } else {
@@ -129,14 +130,9 @@ export default function MusicForm({ token, initial, onSuccess, onCancel }: Music
       )}
 
       <div className={f.field}>
-        <label className={f.label} htmlFor="music-art">
-          Album art {initial && <span className={f.immutableNote}>(cannot be changed after creation)</span>}
-        </label>
-        {initial ? (
-          <p className={f.immutableNote}>Current: {initial.albumArt || 'none'}</p>
-        ) : (
-          <input id="music-art" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setAlbumArtFile(e.target.files?.[0] ?? null)} disabled={loading} />
-        )}
+        <label className={f.label} htmlFor="music-art">Album art</label>
+        {initial && <p className={f.immutableNote}>Current: {initial.albumArt || 'none'}</p>}
+        <input id="music-art" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setAlbumArtFile(e.target.files?.[0] ?? null)} disabled={loading} />
       </div>
 
       <div className={f.field}>

--- a/app/antipratik-ui/src/components/Admin/VideoForm/VideoForm.tsx
+++ b/app/antipratik-ui/src/components/Admin/VideoForm/VideoForm.tsx
@@ -35,6 +35,7 @@ export default function VideoForm({ token, initial, onSuccess, onCancel }: Video
         if (videoURL !== initial.videoUrl) fd.append('videoURL', videoURL);
         if (duration && parseInt(duration) !== initial.duration) fd.append('duration', duration);
         if (playlist !== (initial.playlist ?? '')) fd.append('playlist', playlist);
+        if (thumbnailFile) fd.append('thumbnailFile', thumbnailFile);
         tags.forEach((t) => fd.append('tags[]', t));
         await updateVideoPost(initial.id, fd, token);
       } else {
@@ -81,14 +82,9 @@ export default function VideoForm({ token, initial, onSuccess, onCancel }: Video
       </div>
 
       <div className={f.field}>
-        <label className={f.label} htmlFor="video-thumb">
-          Thumbnail {initial && <span className={f.immutableNote}>(cannot be changed after creation)</span>}
-        </label>
-        {initial ? (
-          <p className={f.immutableNote}>Current: {initial.thumbnailUrl || 'none'}</p>
-        ) : (
-          <input id="video-thumb" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setThumbnailFile(e.target.files?.[0] ?? null)} disabled={loading} />
-        )}
+        <label className={f.label} htmlFor="video-thumb">Thumbnail</label>
+        {initial && <p className={f.immutableNote}>Current: {initial.thumbnailUrl || 'none'}</p>}
+        <input id="video-thumb" className={f.fileInput} type="file" accept=".jpg,.jpeg,.png,.webp,.heic,.heif" onChange={(e) => setThumbnailFile(e.target.files?.[0] ?? null)} disabled={loading} />
       </div>
 
       <div className={f.field}>


### PR DESCRIPTION
Closes #98

## Summary
- **BE**: `PUT /api/posts/music/{id}`, `PUT /api/posts/video/{id}`, and `PUT /api/posts/link/{id}` now accept `albumArtFile` / `thumbnailFile` multipart fields to replace existing images
- **BE**: Logic layer collects old file storage keys before the store update, then deletes them in a background goroutine after success (same pattern as `DeletePost`) — errors logged but non-fatal
- **FE**: Admin forms for music, video, and link posts no longer mark these image fields as "(cannot be changed after creation)"; the file input is shown in both create and edit mode, with the current image URL displayed above it in edit mode

## Scope
Both — backend handles upload + old-file cleanup; frontend exposes the inputs

## Test plan
- [ ] Create a music post with album art → edit → upload new album art → confirm new art renders, old files removed from storage
- [ ] Create a video post with thumbnail → edit → upload new thumbnail → confirm replacement
- [ ] Create a link post with thumbnail → edit → upload new thumbnail → confirm replacement
- [ ] Edit any of the above without changing the image → confirm existing files are untouched
- [ ] `CGO_ENABLED=0 go vet ./...` produces zero errors
- [ ] `npm run lint && npm run typecheck` produces zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)